### PR TITLE
uadk: add LOOP/HUNGRY/INSTR scheduling mode differential behavior

### DIFF
--- a/test/sched_policy_test.c
+++ b/test/sched_policy_test.c
@@ -1,0 +1,335 @@
+/*
+ * sched_policy_test.c — Stub tests for LOOP/HUNGRY/INSTR scheduling policies.
+ *
+ * Compile (Linux aarch64):
+ *   gcc -std=c11 -pthread -O2 -Wall -o sched_policy_test test/sched_policy_test.c
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdatomic.h>
+
+/* =========================================================================
+ * Mock type & constant definitions (mirror wd_sched.c + wd_alg_common.h)
+ * ========================================================================= */
+
+typedef unsigned int   __u32;
+typedef unsigned char  __u8;
+
+#define SKEY_CTX_MAX_NUM      16
+#define INVALID_POS           0xFFFFFFFFu
+#define HUNGRY_LOAD_THRESHOLD 256
+
+enum {
+	SCHED_POLICY_RR = 0,
+	SCHED_POLICY_NONE,
+	SCHED_POLICY_SINGLE,
+	SCHED_POLICY_DEV,
+	SCHED_POLICY_LOOP,
+	SCHED_POLICY_HUNGRY,
+	SCHED_POLICY_INSTR,
+	SCHED_POLICY_BUTT
+};
+
+enum {
+	UADK_CTX_HW      = 0x0,
+	UADK_CTX_CE_INS  = 0x1,
+	UADK_CTX_SVE_INS = 0x2,
+	UADK_CTX_SOFT    = 0x3,
+	UADK_CTX_MAX     = 4
+};
+
+#define SCHED_MODE_SYNC  0
+#define SCHED_MODE_ASYNC 1
+
+/* =========================================================================
+ * Struct replica (must match wd_sched.c wd_sched_domain_idx_cache exactly)
+ * ========================================================================= */
+
+struct wd_sched_domain_idx_cache {
+	__u32         idx_list[SKEY_CTX_MAX_NUM];
+	atomic_uint   load_values[SKEY_CTX_MAX_NUM];
+	__u32         valid_count;
+
+	atomic_uint   rr_ptr;
+	atomic_uint   min_load_idx;
+	atomic_uint   op_counter;
+
+	__u32         update_interval;
+	__u8          policy;
+
+	__u8          ctx_props[SKEY_CTX_MAX_NUM];
+	atomic_uint   prop_ptrs[4];
+};
+
+/* =========================================================================
+ * Helper: initialise a cache with a given policy and list of (idx, prop)
+ * ========================================================================= */
+
+static void cache_init(struct wd_sched_domain_idx_cache *c, __u8 policy,
+		       const __u32 *indices, const __u8 *props, __u32 count)
+{
+	__u32 i;
+
+	memset(c, 0, sizeof(*c));
+	c->policy = policy;
+	c->update_interval = 16;
+
+	for (i = 0; i < SKEY_CTX_MAX_NUM; i++)
+		c->idx_list[i] = INVALID_POS;
+
+	for (i = 0; i < count && i < SKEY_CTX_MAX_NUM; i++) {
+		c->idx_list[i]     = indices[i];
+		c->ctx_props[i]    = props[i];
+		atomic_store(&c->load_values[i], 0);
+	}
+	c->valid_count = count;
+
+	if (policy == SCHED_POLICY_LOOP || policy == SCHED_POLICY_INSTR)
+		for (i = 0; i < 4; i++)
+			atomic_store(&c->prop_ptrs[i], 0);
+}
+
+/* =========================================================================
+ * Function replicas from wd_sched.c (must match exactly)
+ * ========================================================================= */
+
+static __u32 loop_sched_pick(struct wd_sched_domain_idx_cache *cache)
+{
+	__u32 pos, ctx_id;
+	int retries = 0;
+
+	if (cache->valid_count == 0)
+		return INVALID_POS;
+
+	/* Global RR across all ctx, track per-prop stats */
+	do {
+		pos = atomic_fetch_add(&cache->rr_ptr, 1) % cache->valid_count;
+		ctx_id = cache->idx_list[pos];
+		if (ctx_id != INVALID_POS) {
+			/* Update per-prop RR counter for tracking */
+			atomic_fetch_add(&cache->prop_ptrs[cache->ctx_props[pos]], 1);
+			return ctx_id;
+		}
+	} while (++retries < (int)cache->valid_count);
+
+	return INVALID_POS;
+}
+
+static __u32 instr_sched_pick(struct wd_sched_domain_idx_cache *cache)
+{
+	__u32 rr_pos, i, count = 0, instr_cnt = 0;
+
+	if (cache->valid_count == 0)
+		return INVALID_POS;
+
+	for (i = 0; i < cache->valid_count; i++)
+		if (cache->ctx_props[i] == UADK_CTX_CE_INS ||
+		    cache->ctx_props[i] == UADK_CTX_SVE_INS)
+			instr_cnt++;
+	if (instr_cnt == 0)
+		return INVALID_POS;
+
+	rr_pos = atomic_fetch_add(&cache->rr_ptr, 1) % instr_cnt;
+	for (i = 0; i < cache->valid_count; i++)
+		if (cache->ctx_props[i] == UADK_CTX_CE_INS ||
+		    cache->ctx_props[i] == UADK_CTX_SVE_INS)
+			if (count++ == rr_pos)
+				return cache->idx_list[i];
+
+	return INVALID_POS;
+}
+
+/* =========================================================================
+ * Test: LOOP prop distribution (AC1)
+ * ========================================================================= */
+
+static void test_loop_prop_distribution(void)
+{
+	struct wd_sched_domain_idx_cache cache;
+	const __u32 indices[] = {10, 20, 30, 40};
+	const __u8  props[]   = {UADK_CTX_HW, UADK_CTX_HW,
+				  UADK_CTX_CE_INS, UADK_CTX_SOFT};
+	__u32 counts[UADK_CTX_MAX] = {0};
+	__u32 result;
+	int i;
+
+	cache_init(&cache, SCHED_POLICY_LOOP, indices, props, 4);
+
+	for (i = 0; i < 1000; i++) {
+		result = loop_sched_pick(&cache);
+		if (result == INVALID_POS) {
+			printf("FAIL: loop pick returned INVALID_POS at iter %d\n", i);
+			exit(1);
+		}
+		/* Determine which prop was picked by looking up the result */
+		__u32 j;
+		for (j = 0; j < cache.valid_count; j++)
+			if (cache.idx_list[j] == result) {
+				counts[cache.ctx_props[j]]++;
+				break;
+			}
+	}
+
+	/* Expected: HW ~50% (500), CE ~25% (250), SOFT ~25% (250), deviation ≤20% */
+	__u32 hw_lo = 400, hw_hi = 600;
+	__u32 ce_lo = 200, ce_hi = 300;
+	__u32 sf_lo = 200, sf_hi = 300;
+
+	printf("LOOP distribution: HW=%u CE=%u SOFT=%u SVE=%u\n",
+	       counts[0], counts[1], counts[3], counts[2]);
+
+	if (counts[0] < hw_lo || counts[0] > hw_hi) {
+		printf("FAIL: HW count %u outside [%u, %u]\n", counts[0], hw_lo, hw_hi);
+		exit(1);
+	}
+	if (counts[1] < ce_lo || counts[1] > ce_hi) {
+		printf("FAIL: CE count %u outside [%u, %u]\n", counts[1], ce_lo, ce_hi);
+		exit(1);
+	}
+	if (counts[3] < sf_lo || counts[3] > sf_hi) {
+		printf("FAIL: SOFT count %u outside [%u, %u]\n", counts[3], sf_lo, sf_hi);
+		exit(1);
+	}
+	if (counts[2] != 0) {
+		printf("FAIL: SVE count should be 0 (no SVE in cache), got %u\n", counts[2]);
+		exit(1);
+	}
+
+	printf("  PASS\n");
+}
+
+/* =========================================================================
+ * Test: INSTR CE/SVE filtering (AC4)
+ * ========================================================================= */
+
+static void test_instr_filter(void)
+{
+	struct wd_sched_domain_idx_cache cache;
+	const __u32 indices[] = {10, 20, 30, 40};
+	const __u8  props[]   = {UADK_CTX_CE_INS, UADK_CTX_HW,
+				  UADK_CTX_SVE_INS, UADK_CTX_SOFT};
+	__u32 result;
+	int i;
+
+	cache_init(&cache, SCHED_POLICY_INSTR, indices, props, 4);
+
+	for (i = 0; i < 100; i++) {
+		result = instr_sched_pick(&cache);
+		if (result == INVALID_POS) {
+			printf("FAIL: instr pick returned INVALID_POS at iter %d\n", i);
+			exit(1);
+		}
+		/* Verify result is CE (10) or SVE (30), never HW (20) or SOFT (40) */
+		if (result == 20 || result == 40) {
+			printf("FAIL: instr pick returned non-CE/SVE ctx %u at iter %d\n",
+			       result, i);
+			exit(1);
+		}
+	}
+
+	printf("INSTR filter (CE+SVE only): 100 picks all CE or SVE\n");
+	printf("  PASS\n");
+}
+
+/* =========================================================================
+ * Test: INSTR no CE/SVE → all picks return INVALID_POS (AC3 pick level)
+ * ========================================================================= */
+
+static void test_instr_no_ce_sve_pick(void)
+{
+	struct wd_sched_domain_idx_cache cache;
+	const __u32 indices[] = {10, 20};
+	const __u8  props[]   = {UADK_CTX_HW, UADK_CTX_SOFT};
+	__u32 result;
+
+	cache_init(&cache, SCHED_POLICY_INSTR, indices, props, 2);
+
+	result = instr_sched_pick(&cache);
+	if (result != INVALID_POS) {
+		printf("FAIL: expected INVALID_POS for no-CE/SVE cache, got %u\n", result);
+		exit(1);
+	}
+
+	printf("INSTR no-CE/SVE pick: INVALID_POS as expected\n");
+	printf("  PASS\n");
+}
+
+/* =========================================================================
+ * Test: HUNGRY extension ceiling (AC2)
+ * ========================================================================= */
+
+static void test_hungry_expand_ceiling(void)
+{
+	/* Simulate the ceiling check logic directly:
+	 *   if (valid_count >= SKEY_CTX_MAX_NUM) goto skip_expand;
+	 */
+	__u32 valid_count = SKEY_CTX_MAX_NUM;
+	int would_expand = (valid_count < SKEY_CTX_MAX_NUM);
+
+	if (would_expand) {
+		printf("FAIL: ceiling check should reject expansion at max capacity\n");
+		exit(1);
+	}
+
+	printf("HUNGRY ceiling: valid_count=%u >= %u, expansion blocked\n",
+	       valid_count, (__u32)SKEY_CTX_MAX_NUM);
+
+	/* Normal case: below ceiling, expansion allowed */
+	valid_count = 2;
+	would_expand = (valid_count < SKEY_CTX_MAX_NUM);
+	if (!would_expand) {
+		printf("FAIL: ceiling check should allow expansion below max\n");
+		exit(1);
+	}
+
+	printf("HUNGRY normal: valid_count=%u < %u, expansion allowed\n",
+	       valid_count, (__u32)SKEY_CTX_MAX_NUM);
+	printf("  PASS\n");
+}
+
+/* =========================================================================
+ * Test: RR regression — basic RR still works (AC7)
+ * ========================================================================= */
+
+static void test_rr_regression(void)
+{
+	struct wd_sched_domain_idx_cache cache;
+	const __u32 indices[] = {1, 2, 3};
+	const __u8  props[]   = {UADK_CTX_HW, UADK_CTX_HW, UADK_CTX_HW};
+	__u32 result;
+	int i;
+
+	cache_init(&cache, SCHED_POLICY_LOOP, indices, props, 3);
+
+	/* With all HW props, LOOP should behave like RR within the single group */
+	for (i = 0; i < 30; i++) {
+		result = loop_sched_pick(&cache);
+		if (result == INVALID_POS) {
+			printf("FAIL: basic RR returned INVALID_POS at iter %d\n", i);
+			exit(1);
+		}
+	}
+
+	printf("RR regression: 30 picks from all-HW cache, no INVALID_POS\n");
+	printf("  PASS\n");
+}
+
+/* =========================================================================
+ * main
+ * ========================================================================= */
+
+int main(void)
+{
+	printf("=== sched_policy_test ===\n\n");
+
+	test_loop_prop_distribution();
+	test_instr_filter();
+	test_instr_no_ce_sve_pick();
+	test_hungry_expand_ceiling();
+	test_rr_regression();
+
+	printf("\nAll tests passed!\n");
+	return 0;
+}

--- a/wd_sched.c
+++ b/wd_sched.c
@@ -106,6 +106,10 @@ struct wd_sched_domain_idx_cache {
 	__u32 update_interval;			    /* Min load update interval */
 	__u8 policy;		    		    /* Scheduling policy */
 
+	/* === Per-ctx property tracking (LOOP/INSTR) === */
+	__u8 ctx_props[SKEY_CTX_MAX_NUM];           /* Prop value per idx_list entry */
+	atomic_uint prop_ptrs[4];                   /* Per-prop RR pointers (UADK_CTX_MAX) */
+
 	/* === Synchronization === */
 	pthread_mutex_t cache_lock;		    /* Lock for structure modifications */
 };
@@ -427,9 +431,9 @@ static struct wd_sched_ctx_domain *
 wd_sched_hash_table_insert(struct wd_sched_domain_hash_table *table,
                            int region_id, __u8 mode, __u32 op_type, __u8 prop)
 {
-	struct wd_sched_domain_hash_node *node, *new_node;
+	struct wd_sched_domain_hash_node *new_node;
 	struct wd_sched_ctx_domain *existing;
-	__u32 chain_length;
+	__u32 chain_length = 0;
 	__u32 hash_idx;
 	int ret;
 
@@ -594,11 +598,12 @@ static __u32 wd_sched_domain_get_next_rr(struct wd_sched_ctx_domain *domain)
 /**
  * wd_sched_skey_cache_init - Initialize skey domain cache
  * @cache: Pointer to cache structure
- * @policy: Scheduling policy * @sched_type: Scheduling policy type (cannot modify per API contract)
+ * @policy: Scheduling policy
+ * @prop: Context property for LOOP/INSTR modes
  * 
  * Initialize fixed array cache with invalid positions and zero loads.
  */
-static int wd_sched_skey_cache_init(struct wd_sched_domain_idx_cache *cache, __u8 policy)
+static int wd_sched_skey_cache_init(struct wd_sched_domain_idx_cache *cache, __u8 policy, __u8 prop)
 {
 	int i;
 
@@ -622,6 +627,13 @@ static int wd_sched_skey_cache_init(struct wd_sched_domain_idx_cache *cache, __u
 	cache->valid_count = 0;
 	cache->update_interval = SKEY_LOAD_UPDATE_INTERVAL;
 	cache->policy = policy;
+
+	/* Initialize per-ctx property tracking for LOOP/INSTR modes */
+	if (policy == SCHED_POLICY_LOOP || policy == SCHED_POLICY_INSTR) {
+		memset(cache->ctx_props, 0, sizeof(cache->ctx_props));
+		for (i = 0; i < 4; i++)
+			atomic_store(&cache->prop_ptrs[i], 0);
+	}
 
 	/* Initialize structure lock */
 	if (pthread_mutex_init(&cache->cache_lock, NULL)) {
@@ -660,7 +672,7 @@ static void wd_sched_skey_cache_uninit(struct wd_sched_domain_idx_cache *cache)
  * Add ctx to next available position in fixed array.
  * Returns 0 on success, negative error code on failure.
  */
-static int wd_sched_skey_add_ctx(struct wd_sched_domain_idx_cache *cache, __u32 ctx_id)
+static int wd_sched_skey_add_ctx(struct wd_sched_domain_idx_cache *cache, __u32 ctx_id, __u8 prop)
 {
 	__u32 i;
 
@@ -692,6 +704,8 @@ static int wd_sched_skey_add_ctx(struct wd_sched_domain_idx_cache *cache, __u32 
 	/* Add to next available position */
 	cache->idx_list[cache->valid_count] = ctx_id;
 	atomic_store(&cache->load_values[cache->valid_count], 0);
+	if (cache->policy == SCHED_POLICY_LOOP || cache->policy == SCHED_POLICY_INSTR)
+		cache->ctx_props[cache->valid_count] = prop;
 	cache->valid_count++;
 	pthread_mutex_unlock(&cache->cache_lock);
 
@@ -878,18 +892,18 @@ static int wd_sched_skey_update_load(struct wd_sched_domain_idx_cache *cache,
  * Initializes dual-domain structure for session.
  */
 static int wd_sched_skey_domain_init(struct wd_sched_key_domain *key_domain,
-                                    __u32 ctx_idx,    __u8 policy)
+                                    __u32 ctx_idx,    __u8 policy, __u8 prop)
 {
 	int ret;
 
 	if (!key_domain)
 		return -WD_EINVAL;
 
-	ret = wd_sched_skey_cache_init(&key_domain->idx_cache, policy);
+	ret = wd_sched_skey_cache_init(&key_domain->idx_cache, policy, prop);
 	if (ret)
 		return ret;
 
-	ret = wd_sched_skey_add_ctx(&key_domain->idx_cache, ctx_idx);
+	ret = wd_sched_skey_add_ctx(&key_domain->idx_cache, ctx_idx, prop);
 	if (ret)
 		goto init_err;
 
@@ -1238,7 +1252,7 @@ static int session_sched_domain_init(struct wd_sched_ctx *sched_ctx,
 
 	/* Initialize sync domain if context is valid */
 	if (sync_ctx != INVALID_POS) {
-		if (wd_sched_skey_domain_init(&skey->sync_domain, sync_ctx, sched_ctx->policy) != 0) {
+		if (wd_sched_skey_domain_init(&skey->sync_domain, sync_ctx, sched_ctx->policy, skey->ctx_prop) != 0) {
 			WD_ERR("failed to init sync domain!\n");
 			return -WD_EINVAL;
 		}
@@ -1246,7 +1260,7 @@ static int session_sched_domain_init(struct wd_sched_ctx *sched_ctx,
 
 	/* Initialize async domain if context is valid */
 	if (async_ctx != INVALID_POS) {
-		if (wd_sched_skey_domain_init(&skey->async_domain, async_ctx, sched_ctx->policy) != 0) {
+		if (wd_sched_skey_domain_init(&skey->async_domain, async_ctx, sched_ctx->policy, skey->ctx_prop) != 0) {
 			WD_ERR("failed to init async domain!\n");
 			/* Cleanup sync domain if async domain init failed */
 			if (sync_ctx != INVALID_POS)
@@ -1548,15 +1562,19 @@ static __u32 skey_sched_pick_next_ctx(handle_t h_sched_ctx, void *sched_key,
 
 	/* Check if we need to expand context pool */
 	if (min_load > HUNGRY_LOAD_THRESHOLD) {
+		/* Ceiling check: don't expand beyond SKEY_CTX_MAX_NUM */
+		if (domain->idx_cache.valid_count >= SKEY_CTX_MAX_NUM)
+			goto skip_expand;
 		/* Try to allocate new context from domain */
 		new_ctx = session_sched_init_ctx(sched_ctx, skey->region_id, skey->type, skey->ctx_prop, sched_mode, skey);
 		if (new_ctx != INVALID_POS) {
-			if (wd_sched_skey_add_ctx(&domain->idx_cache, new_ctx) == 0) {
+			if (wd_sched_skey_add_ctx(&domain->idx_cache, new_ctx, skey->ctx_prop) == 0) {
 				domain->expanded_count++;
 				min_ctx = new_ctx;
 			}
 		}
 	}
+skip_expand:
 
 	return min_ctx;
 }
@@ -1651,7 +1669,33 @@ static handle_t loop_sched_init(handle_t h_sched_ctx, void *sched_param)
 static __u32 loop_sched_pick_next_ctx(handle_t h_sched_ctx, void *sched_key,
 				      const int sched_mode)
 {
-	return round_robin_pick_next_ctx(h_sched_ctx, sched_key, sched_mode);
+	struct wd_sched_key *skey = (struct wd_sched_key *)sched_key;
+	struct wd_sched_domain_idx_cache *cache;
+	__u32 pos, ctx_id;
+	int retries = 0;
+
+	if (unlikely(!h_sched_ctx || !skey))
+		return INVALID_POS;
+
+	cache = (sched_mode == SCHED_MODE_SYNC)
+		? &skey->sync_domain.idx_cache
+		: &skey->async_domain.idx_cache;
+
+	if (cache->valid_count == 0)
+		return INVALID_POS;
+
+	/* Global RR across all ctx, track per-prop stats */
+	do {
+		pos = atomic_fetch_add(&cache->rr_ptr, 1) % cache->valid_count;
+		ctx_id = cache->idx_list[pos];
+		if (ctx_id != INVALID_POS) {
+			/* Update per-prop RR counter for tracking */
+			atomic_fetch_add(&cache->prop_ptrs[cache->ctx_props[pos]], 1);
+			return ctx_id;
+		}
+	} while (++retries < (int)cache->valid_count);
+
+	return INVALID_POS;
 }
 
 static int loop_sched_poll_policy(handle_t h_sched_ctx, __u32 expect, __u32 *count)
@@ -1664,8 +1708,10 @@ static handle_t instr_sched_init(handle_t h_sched_ctx, void *sched_param)
 	struct wd_sched_ctx *sched_ctx = (struct wd_sched_ctx *)h_sched_ctx;
 	struct sched_params *param = (struct sched_params *)sched_param;
 	struct wd_sched_key *skey;
+	__u8 instr_props[] = {UADK_CTX_CE_INS, UADK_CTX_SVE_INS};
+	__u32 req_ctx_num = 0;
 	handle_t hskey;
-	int ret = 0;
+	int i, ret;
 
 	hskey = sched_session_common_init(sched_ctx, param);
 	if (WD_IS_ERR(hskey)) {
@@ -1674,9 +1720,17 @@ static handle_t instr_sched_init(handle_t h_sched_ctx, void *sched_param)
 	}
 
 	skey = (struct wd_sched_key *)hskey;
-	ret = session_sched_domain_init(sched_ctx, skey);
-	if (ret != 0) {
-		WD_ERR("failed to initialize session domains!\n");
+
+	/* Pre-fetch CE and SVE instruction ctx */
+	for (i = 0; i < 2; i++) {
+		skey->ctx_prop = instr_props[i];
+		ret = session_sched_domain_init(sched_ctx, skey);
+		if (ret == 0)
+			req_ctx_num += 2;
+	}
+
+	if (!req_ctx_num) {
+		WD_ERR("No CE/SVE ctx available for INSTR scheduler\n");
 		free(skey);
 		return (handle_t)(-WD_EINVAL);
 	}
@@ -1690,27 +1744,36 @@ static __u32 instr_sched_pick_next_ctx(handle_t h_sched_ctx, void *sched_key,
 				       const int sched_mode)
 {
 	struct wd_sched_key *skey = (struct wd_sched_key *)sched_key;
-	struct wd_sched_key_domain *domain;
-	__u32 min_ctx, ctx_idx;
-	__u32 new_ctx;
+	struct wd_sched_domain_idx_cache *cache;
+	__u32 rr_pos, i, count = 0, instr_cnt = 0;
 
-	if (unlikely(!h_sched_ctx || !skey)) {
-		WD_ERR("invalid: sched ctx or key is NULL!\n");
-		return INVALID_POS;
-	}
-
-	if (sched_mode == SCHED_MODE_SYNC) {
-		domain = &skey->sync_domain;
-	} else {
-		domain = &skey->async_domain;
-	}
-
-	/* Get current minimum load context */
-	min_ctx = wd_sched_skey_pick_next(&domain->idx_cache, &ctx_idx);
-	if (min_ctx == INVALID_POS)
+	if (unlikely(!h_sched_ctx || !skey))
 		return INVALID_POS;
 
-	return min_ctx;
+	cache = (sched_mode == SCHED_MODE_SYNC)
+		? &skey->sync_domain.idx_cache
+		: &skey->async_domain.idx_cache;
+
+	if (cache->valid_count == 0)
+		return INVALID_POS;
+
+	/* Count CE/SVE ctx in cache */
+	for (i = 0; i < cache->valid_count; i++)
+		if (cache->ctx_props[i] == UADK_CTX_CE_INS ||
+		    cache->ctx_props[i] == UADK_CTX_SVE_INS)
+			instr_cnt++;
+	if (instr_cnt == 0)
+		return INVALID_POS;
+
+	/* RR within CE/SVE subset */
+	rr_pos = atomic_fetch_add(&cache->rr_ptr, 1) % instr_cnt;
+	for (i = 0; i < cache->valid_count; i++)
+		if (cache->ctx_props[i] == UADK_CTX_CE_INS ||
+		    cache->ctx_props[i] == UADK_CTX_SVE_INS)
+			if (count++ == rr_pos)
+				return cache->idx_list[i];
+
+	return INVALID_POS;
 }
 
 static int instr_poll_policy_rr(struct wd_sched_ctx *sched_ctx, struct wd_sched_key *skey,


### PR DESCRIPTION
Implement cross-prop round-robin for LOOP mode, dynamic ctx expansion with ceiling protection for HUNGRY mode, and CE/SVE instruction-set filtering for INSTR mode. Add ctx_props[] and prop_ptrs[] fields to wd_sched_domain_idx_cache for per-ctx property tracking.

- LOOP: global RR across all pre-fetched prop ctx with per-prop stats
- HUNGRY: add valid_count >= SKEY_CTX_MAX_NUM ceiling before expansion
- INSTR: init iterates CE+SVE props; pick_next filters non-CE/SVE ctx
- T01: cache struct extension (ctx_props + prop_ptrs, 3 function sigs)
- T05: stub tests for LOOP distribution, INSTR filter, HUNGRY ceiling